### PR TITLE
feat: be generic, support any SQLx database

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ features = [ "rustls" ]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+default = ["rustls", "postgres"]
 docs = ["rustls"]
 
 # database
-any = [ "sqlx/any" ]
 postgres = [ "sqlx/postgres"]
 mysql = [ "sqlx/mysql" ]
 sqlite = [ "sqlx/sqlite" ]
@@ -37,12 +37,7 @@ rustls = [ "sqlx/runtime-async-std-rustls" ]
 
 [dependencies]
 async-std = "1.7.0"
-either = "1.6.1"
-futures-core = "0.3.8"
-
-[dependencies.sqlx]
-version = "0.4.1"
-features = ["postgres"]
+sqlx = "0.4.1"
 
 [dependencies.tide]
 version = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,22 +18,22 @@ categories = [
 ]
 
 [package.metadata.docs.rs]
-features = [ "rustls" ]
+features = ["docs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["rustls", "postgres"]
-docs = ["rustls"]
+default = ["rustls"]
+docs = ["rustls", "postgres"]
 
 # database
-postgres = [ "sqlx/postgres"]
-mysql = [ "sqlx/mysql" ]
-sqlite = [ "sqlx/sqlite" ]
-mssql = [ "sqlx/mssql" ]
+postgres = ["sqlx/postgres"]
+mysql = ["sqlx/mysql"]
+sqlite = ["sqlx/sqlite"]
+mssql = ["sqlx/mssql"]
 
 # tls implementation
-native-tls = [ "sqlx/runtime-async-std-native-tls" ]
-rustls = [ "sqlx/runtime-async-std-rustls" ]
+native-tls = ["sqlx/runtime-async-std-native-tls"]
+rustls = ["sqlx/runtime-async-std-rustls"]
 
 [dependencies]
 async-std = "1.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@ use sqlx::{Database, Transaction};
 use tide::utils::async_trait;
 use tide::{http::Method, Middleware, Next, Request, Result};
 
+#[cfg(all(test, not(feature = "postgres")))]
+compile_error!("The tests must be run with --features=postgres");
+
 #[doc(hidden)]
 pub enum ConnectionWrapInner<DB: Database> {
     Transacting(Transaction<'static, DB>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,26 @@ impl<DB: Database> Debug for ConnectionWrapInner<DB> {
     }
 }
 
+impl<DB: Database> Deref for ConnectionWrapInner<DB> {
+    type Target = DB::Connection;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            ConnectionWrapInner::Plain(c) => c,
+            ConnectionWrapInner::Transacting(c) => c,
+        }
+    }
+}
+
+impl<DB: Database> DerefMut for ConnectionWrapInner<DB> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            ConnectionWrapInner::Plain(c) => c,
+            ConnectionWrapInner::Transacting(c) => c,
+        }
+    }
+}
+
 #[doc(hidden)]
 pub type ConnectionWrap<DB> = Arc<RwLock<ConnectionWrapInner<DB>>>;
 
@@ -255,25 +275,5 @@ impl<T: Send + Sync + 'static> SQLxRequestExt for Request<T> {
             .ext()
             .expect("You must install SQLx middleware providing ConnectionWrap");
         sqlx_conn.write().await
-    }
-}
-
-impl<DB: Database> Deref for ConnectionWrapInner<DB> {
-    type Target = DB::Connection;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            ConnectionWrapInner::Plain(c) => c,
-            ConnectionWrapInner::Transacting(c) => c,
-        }
-    }
-}
-
-impl<DB: Database> DerefMut for ConnectionWrapInner<DB> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        match self {
-            ConnectionWrapInner::Plain(c) => c,
-            ConnectionWrapInner::Transacting(c) => c,
-        }
     }
 }


### PR DESCRIPTION
This changes a lot of this crate to be generic over `sqlx::Database`,
and also changes the naming of everything to be "SQLx*".

Additionally, this now has a greatly simplified `ConnectionWrapInner`
implementation via `Deref` and `DerefMut`! Thanks to @mehcode for that!

----

Future improvements, either in this PR or in follow-ups include: 
- `tide_sqlx::PostgresMiddleware` (and etc) as aliases to e.g. `tide_sqlx::SQLxMiddleware<Postgres>` when the postgres feature is enabled.
- `tide_sqlx::PostgresRequestExt` (and etc) as shortcusts to allow `req.postgres_conn()` rather than `req.sqlx_conn::<Postgres>()`.

----

note to self: still need to remove the `"postgres"` and `"any"` features by default, only include in test runs