### PR TITLE
feat: From<Pool> for SQLxMiddleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ default-features = false
 
 [dev-dependencies]
 anyhow = "1.0.34"
+log = "0.4.11"
 
 [dev-dependencies.async-std]
 version = "1.7.0"


### PR DESCRIPTION
Allows a creating a middleware instance directly from an `sqlx::Pool`, which is useful if you want to apply arbitrary connection options or pool options. This saves us replicating all of that.