### PR TITLE
WIP unsafe nested transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["rustls"]
+default = ["rustls", "test"]
 docs = ["rustls", "postgres"]
-test = ["rustls", "postgres"]
+test = ["rustls", "postgres", "unsafe-nested-transactions"]
+
+unsafe-nested-transactions = []
 
 # database
 any = ["sqlx/any"]


### PR DESCRIPTION
This is... certainly risky, but it does work.

That being said, I am not sure it is really memory-safe as per this patch. Rustc doesn't complain but I am pretty sure the borrow we are extending has to be pinned to ensure the original context's memory doesn't get re-positioned. Not 100% sure but pretty sure. Can't hurt for safety. Just requires me put another couple hours at it.