### PR TITLE
deps: update `sqlx` to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rustls = ["sqlx/runtime-async-std-rustls"]
 
 [dependencies]
 async-std = "1"
-sqlx = "0.4"
+sqlx = "0.5"
 
 [dependencies.tide]
 version = "0.16"


### PR DESCRIPTION
I wasn't entirely sure whether you wanted me to open a new PR for this change or just remove it from #12, but seeing as I needed the change immediately, I had to implement it anyway, so might as well try and upstream it. If you're not ready to do this or have other plans, feel free to close this.

---

This builds on #12, deprecates #11, and resolves #13.