### PR TITLE
Enable Sqlite support by updating the SQLx dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rustls = ["sqlx/runtime-async-std-rustls"]
 
 [dependencies]
 async-std = "1"
-sqlx = "0.7.4"
+sqlx = "0.8.6"
 
 [dependencies.tracing_crate]
 version = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rustls = ["sqlx/runtime-async-std-rustls"]
 
 [dependencies]
 async-std = "1"
-sqlx = "0.5"
+sqlx = "0.7.4"
 
 [dependencies.tracing_crate]
 version = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //! use tide_sqlx::SQLxRequestExt;
 //!
 //! let mut connect_opts = PgConnectOptions::new();
-//! connect_opts.log_statements(LevelFilter::Debug);
+//! let mut connect_opts = connect_opts.log_statements(LevelFilter::Debug);
 //!
 //! let pg_pool = PgPoolOptions::new()
 //!     .max_connections(5)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@
 //! use tide_sqlx::SQLxMiddleware;
 //! use tide_sqlx::SQLxRequestExt;
 //!
-//! let mut connect_opts = PgConnectOptions::new();
-//! let mut connect_opts = connect_opts.log_statements(LevelFilter::Debug);
+//! let connect_opts = PgConnectOptions::new()
+//!     .log_statements(LevelFilter::Debug);
 //!
 //! let pg_pool = PgPoolOptions::new()
 //!     .max_connections(5)


### PR DESCRIPTION
Currently Sqlite doesn't work:

```rust
let pool = sqlx::sqlite::SqlitePool::connect(SQLITE_DB_URL).await?;

let mut app = tide::with_state(state);

app.with(SQLxMiddleware::<Sqlite>::from(db)); // Fails because SqliteConnection isn't Send
```

However, by updating the SQLx package dependency from 0.5.4 to 0.8.6, the code above compiles and works.